### PR TITLE
Sub: 네트워크 유틸리티 함수 및 타입 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,10 @@ module.exports = {
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_" }
+    ],
     indent: 'off',
   },
 };

--- a/packages/http-api/network.type.ts
+++ b/packages/http-api/network.type.ts
@@ -43,10 +43,7 @@ export interface HttpApiErrorParser<T, E extends Error = Error> {
   interrupt: <E extends Error>(error: E) => Promise<void>;
 }
 
-/**
- * HTTP 프로토콜을 이용하여 비동기 통신을 수행한다.
- */
-export interface HttpApi {
+export interface HttpRestApi {
   /**
    * GET 메서드 호출
    * @param url 호출 경로
@@ -102,6 +99,9 @@ export interface HttpApi {
     params?: P,
     timeout?: number
   ): Promise<T>;
+}
+
+export interface HttpUploadApi {
   /**
    * POST 메서드로 업로드 한다.
    * @param url 업로드 경로
@@ -134,6 +134,9 @@ export interface HttpApi {
     progCallback?: (args: UploadStateArgs) => void,
     timeout?: number
   ): Promise<T>;
+}
+
+export interface HttpFileApi {
   /**
    * GET 메서드로 파일을 비동기로 가져온다.
    * @param url 파일을 가져올 경로
@@ -154,4 +157,42 @@ export interface HttpApi {
     url: string,
     params?: P
   ): Promise<Blob>;
+}
+
+/**
+ * HTTP 프로토콜을 이용하여 비동기 통신을 수행한다.
+ */
+export interface HttpApi extends HttpRestApi, HttpFileApi {}
+
+export type RestHttpMethodType = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export interface BaseAsyncHttpNetworkConfig {
+  url: string;
+  headers: Record<string, string>;
+  withCredentials?: boolean;
+  timeout?: number;
+}
+
+export interface AsyncHttpNetworkConfig extends BaseAsyncHttpNetworkConfig {
+  params?: any;
+  paramsSerializer?: (params: any) => string;
+}
+
+export interface AsyncHttpNetworkProvider {
+  get<T>(config: AsyncHttpNetworkConfig): Promise<T>;
+  post<T>(config: AsyncHttpNetworkConfig): Promise<T>;
+  put<T>(config: AsyncHttpNetworkConfig): Promise<T>;
+  patch<T>(config: AsyncHttpNetworkConfig): Promise<T>;
+  delete<T>(config: AsyncHttpNetworkConfig): Promise<T>;
+  getBlob(config: AsyncHttpNetworkConfig): Promise<Blob>;
+}
+
+export interface AsyncHttpUploadConfig extends BaseAsyncHttpNetworkConfig {
+  data: Record<string, string | File | File[]>;
+  onProgress?: (args: UploadStateArgs) => void;
+}
+
+export interface AsyncHttpUploadProvider {
+  post<T>(config: AsyncHttpUploadConfig): Promise<T>;
+  put<T>(config: AsyncHttpUploadConfig): Promise<T>;
 }

--- a/packages/http-api/network.util.test.ts
+++ b/packages/http-api/network.util.test.ts
@@ -1,0 +1,158 @@
+import { HttpRestError, HttpRestErrorLike } from '../types';
+import {
+  isBaseAsyncHttpNetworkConfig,
+  throwHttpRestError,
+} from './network.util';
+
+describe('isBaseAsyncHttpNetworkConfig', () => {
+  it('nullish 에 대응되는 값이면 false 다.', () => {
+    const result1 = isBaseAsyncHttpNetworkConfig(null);
+    const result2 = isBaseAsyncHttpNetworkConfig(undefined);
+    const result3 = isBaseAsyncHttpNetworkConfig(NaN);
+
+    expect(result1).toBeFalsy();
+    expect(result2).toBeFalsy();
+    expect(result3).toBeFalsy();
+  });
+
+  it('객체값이 아니면 false 다.', () => {
+    const result1 = isBaseAsyncHttpNetworkConfig('');
+    const result2 = isBaseAsyncHttpNetworkConfig(12);
+    const result3 = isBaseAsyncHttpNetworkConfig(true);
+
+    expect(result1).toBeFalsy();
+    expect(result2).toBeFalsy();
+    expect(result3).toBeFalsy();
+  });
+
+  it('url 필드가 비어있다면 false 다.', () => {
+    const result = isBaseAsyncHttpNetworkConfig({
+      url: '',
+      headers: {},
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('headers 필드가 비어있다면 false 다.', () => {
+    const result = isBaseAsyncHttpNetworkConfig({
+      url: 'https://api.theson.kr/haha/hoho/search?q=sonic',
+      headers: null,
+      withCredentials: true,
+      timeout: 0,
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('url 과 headers 필드가 채워져 있다면 true 다.', () => {
+    const result = isBaseAsyncHttpNetworkConfig({
+      url: 'https://api.theson.kr/haha/hoho/search?q=sonic',
+      headers: {
+        token: 'blahblah',
+      },
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('withCredentials 와 timeout 은 있어도 되고 없어도 된다.', () => {
+    const config = {
+      url: 'https://api.theson.kr/haha/hoho/search?q=sonic',
+      headers: {
+        token: 'blahblah',
+      },
+    };
+
+    const result1 = isBaseAsyncHttpNetworkConfig({
+      ...config,
+      withCredentials: true,
+    });
+    const result2 = isBaseAsyncHttpNetworkConfig({ ...config, timeout: 10000 });
+    const result3 = isBaseAsyncHttpNetworkConfig({
+      ...config,
+      withCredentials: false,
+      timeout: 5000,
+    });
+
+    expect(result1).toBeTruthy();
+    expect(result2).toBeTruthy();
+    expect(result3).toBeTruthy();
+  });
+
+  it('withCredentials 와 timeout 은 지정된 타입이어야 한다.', () => {
+    const config = {
+      url: 'https://api.theson.kr/haha/hoho/search?q=sonic',
+      headers: {
+        token: 'blahblah',
+      },
+    };
+
+    const result1 = isBaseAsyncHttpNetworkConfig({
+      ...config,
+      withCredentials: 'throw!!',
+    });
+    const result2 = isBaseAsyncHttpNetworkConfig({ ...config, timeout: false });
+    const result3 = isBaseAsyncHttpNetworkConfig({
+      ...config,
+      withCredentials: {},
+      timeout: () => 1234,
+    });
+
+    expect(result1).toBeFalsy();
+    expect(result2).toBeFalsy();
+    expect(result3).toBeFalsy();
+  });
+});
+
+const undeclaredValues = [null, undefined, '', 1, 0, NaN, {}];
+
+describe('throwHttpRestError', () => {
+  function throwTest(error: unknown) {
+    return () => throwHttpRestError(error);
+  }
+
+  const sample: HttpRestErrorLike = {
+    message: '잘못된 요청입니다.',
+    url: 'https://api.theson.kr/haha/search',
+    errorType: 'badRequest',
+    rawData: {
+      value: 1234,
+      name: 'theson',
+      corp: 'lookpin',
+    },
+  };
+
+  const restError = HttpRestError.from('lookpin error');
+
+  describe('의미 없는 값은 모두 기본 메시지가 적용된다.', () => {
+    it.each(undeclaredValues)('%s 경우', (arg0) => {
+      expect(throwTest(arg0)).toThrowError(HttpRestError.DEFAULT_MESSAGE);
+    });
+  });
+
+  it.each([
+    [
+      '문자열이면 그 내용이 메시지가 된다.', //
+      'lookpin lover',
+      'lookpin lover',
+    ],
+    [
+      '에러 계통이면 에러 메시지를 그대로 이용한다.',
+      new Error('lorem ipsum'),
+      'lorem ipsum',
+    ],
+    [
+      'HttpRestError 와 닮은 꼴이면 그 내용을 그대로 이용한다.',
+      sample,
+      sample.message,
+    ],
+    [
+      'HttpRestError 인스턴스라면 그 내용을 그대로 이용한다.',
+      restError,
+      restError.message,
+    ],
+  ])('%s', (_desc, error, message) => {
+    expect(throwTest(error)).toThrowError(message);
+  });
+});

--- a/packages/http-api/network.util.ts
+++ b/packages/http-api/network.util.ts
@@ -1,0 +1,75 @@
+import { AxiosError } from 'axios';
+import { HttpRestError } from '../types';
+import { isObject, isString, isUndefined, isNumber } from '../util/typeCheck';
+import { BaseAsyncHttpNetworkConfig } from './network.type';
+
+function isOptionalBoolean(value: unknown): value is undefined | boolean {
+  if (isUndefined(value)) {
+    return true;
+  }
+  if (value === true || value === false) {
+    return true;
+  }
+  return false;
+}
+
+function isOptionalNumber(value: unknown): value is undefined | number {
+  if (isUndefined(value)) {
+    return true;
+  }
+  if (isNumber(value)) {
+    return true;
+  }
+  return false;
+}
+
+export function isBaseAsyncHttpNetworkConfig(
+  value: unknown
+): value is BaseAsyncHttpNetworkConfig {
+  if (!value) {
+    return false;
+  }
+  const target = value as Partial<BaseAsyncHttpNetworkConfig>;
+
+  if (!target.url || isString(target.url) === false) {
+    return false;
+  }
+  if (!target.headers || isObject(target.headers) === false) {
+    return false;
+  }
+  if (isOptionalBoolean(target.withCredentials) === false) {
+    return false;
+  }
+  if (isOptionalNumber(target.timeout) === false) {
+    return false;
+  }
+  return true;
+}
+
+export function throwHttpRestError(error: unknown) {
+  if (
+    error &&
+    (HttpRestError.isHttpRestErrorLike(error) ||
+      HttpRestError.isErrorLike(error) ||
+      typeof error === 'string')
+  ) {
+    throw HttpRestError.from(error);
+  }
+
+  throw new HttpRestError(HttpRestError.DEFAULT_MESSAGE, {
+    url: '',
+    status: 0,
+    rawData: error,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isAxiosError(error: any): error is AxiosError {
+  return (
+    error &&
+    error.response &&
+    typeof error.response.status === 'number' &&
+    error.config &&
+    typeof error.config.url === 'string'
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "importHelpers": true,
     "module": "esnext",
     "target": "esnext",
+    "experimentalDecorators": true,
     "jsx": "react",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Updates

기존 HttpApi Factory 에서 쓰였던 기능 일부를 후속 업무에 사용 하기위해 유틸리티로 분리하고 관련 테스트 코드를 작성하였습니다.

## Others

- eslint 규칙 추가
  - @typescript-eslint/no-unused-vars
  - 사유: 함수 내 인자(argument)중 스킵하고 싶은 것들에 대하여 언더바(_)를 앞에 붙이면 lint 규칙을 무시하기 위함입니다.
- typescript decorator 빌드 옵션 추가