### PR TITLE
Sub: ErrorParser decorator 기능 및 테스트코드 작성

### DIFF
--- a/packages/http-api/ErrorParser.decorator.test.ts
+++ b/packages/http-api/ErrorParser.decorator.test.ts
@@ -1,0 +1,212 @@
+import { ErrorParser } from './ErrorParser.decorator';
+import {
+  AsyncHttpNetworkProvider,
+  AsyncHttpUploadProvider,
+  HttpApi,
+  HttpUploadApi,
+} from './network.type';
+
+describe('ErrorParser', () => {
+  function createMockMethod(method: string) {
+    return vi.fn().mockRejectedValue(new Error(`${method}: some error`));
+  }
+  const mockFnDic: HttpApi &
+    HttpUploadApi &
+    AsyncHttpNetworkProvider &
+    AsyncHttpUploadProvider = {
+    get: createMockMethod('get'),
+    put: createMockMethod('put'),
+    post: createMockMethod('post'),
+    patch: createMockMethod('patch'),
+    delete: createMockMethod('delete'),
+    getFile: createMockMethod('getFile'),
+    getBlob: createMockMethod('getBlob'),
+    putUpload: createMockMethod('putUpload'),
+    postUpload: createMockMethod('postUpload'),
+  };
+  const parserMockFn = vi.fn((error) => error);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('메서드 수행 시 parser 인자를 자동으로 수행한다.', () => {
+    @ErrorParser(parserMockFn)
+    class HttpApiMock implements HttpApi {
+      get = mockFnDic.get;
+      put = mockFnDic.put;
+      post = mockFnDic.post;
+      patch = mockFnDic.patch;
+      delete = mockFnDic.delete;
+      getFile = mockFnDic.getFile;
+      getBlob = mockFnDic.getBlob;
+    }
+
+    const methodList = [
+      'get',
+      'put',
+      'post',
+      'patch',
+      'delete',
+      'getFile',
+      'getBlob',
+    ] as const;
+
+    it.each(
+      methodList.map((key) => {
+        return [key, '/some/path', { name: 'theson' }] as const;
+      })
+    )('%s 메서드', async (method, path: string, params) => {
+      const httpApi = new HttpApiMock();
+
+      await expect(
+        (httpApi[method] as CallableFunction)(path, params as never)
+      ).rejects.toThrowError('some');
+
+      expect(parserMockFn).toBeCalled();
+      expect(mockFnDic[method]).toBeCalledWith(path, params);
+    });
+  });
+
+  describe('수행 불가능한 메서드를 임의로 수행 시키면 오류가 발생된다.', async () => {
+    @ErrorParser(parserMockFn)
+    class HttpApiMock implements HttpUploadApi {
+      postUpload = mockFnDic.postUpload;
+      putUpload = mockFnDic.putUpload;
+    }
+
+    const unableMethodList = [
+      'get',
+      'put',
+      'post',
+      'patch',
+      'delete',
+      'getFile',
+      'getBlob',
+    ] as const;
+
+    it.each(
+      unableMethodList.map((key) => {
+        return [key, '/some/path', { name: 'theson' }] as const;
+      })
+    )('%s 메서드 -> 불가', async (method, path: string, params) => {
+      const httpApi = new HttpApiMock();
+
+      expect(() =>
+        (httpApi[method as never] as CallableFunction)(path, params as never)
+      ).toThrowError('of undefined');
+
+      expect(parserMockFn).not.toBeCalled();
+      expect(mockFnDic[method]).not.toBeCalled();
+    });
+
+    const ableMethodList = ['postUpload', 'putUpload'] as const;
+
+    it.each(
+      ableMethodList.map((key, index) => {
+        return [key, `/some/path/${index + 100}`, { name: 'theson' }] as const;
+      })
+    )('%s 메서드 -> 가능', async (method, path: string, params) => {
+      const httpApi = new HttpApiMock();
+
+      await expect(
+        (httpApi[method as never] as CallableFunction)(path, params as never)
+      ).rejects.toThrowError(`${method}: some error`);
+
+      expect(parserMockFn).toBeCalled();
+      expect(mockFnDic[method]).toBeCalledWith(path, params);
+    });
+  });
+
+  describe('단일 메서드 테스트', () => {
+    @ErrorParser(parserMockFn)
+    class NetworkProvider implements AsyncHttpNetworkProvider {
+      get = mockFnDic.get;
+      put = mockFnDic.put;
+      post = mockFnDic.post;
+      patch = mockFnDic.patch;
+      delete = mockFnDic.delete;
+      getBlob = mockFnDic.getBlob;
+    }
+
+    it('parser 수행 중 스스로 오류를 일으키면, 그 내용을 오류값으로 이용한다.', async () => {
+      parserMockFn.mockImplementationOnce(() => {
+        throw new Error('lookpin error');
+      });
+
+      const provider = new NetworkProvider();
+      const path = '/some/path';
+      const data = {
+        name: 'sonic',
+        age: 20,
+        location: 'sega',
+      };
+
+      await expect(provider.post(path, data, 100)).rejects.toThrowError(
+        'lookpin'
+      );
+
+      expect(parserMockFn).toBeCalledTimes(1);
+      expect(mockFnDic.post).toBeCalledWith(path, data, 100);
+    });
+
+    it('parser 수행 중 스스로 오류를 리턴하면, 그 내용을 오류값으로 이용한다.', async () => {
+      parserMockFn.mockImplementationOnce(() => {
+        return new Error('theson error');
+      });
+
+      const provider = new NetworkProvider();
+      const path = '/some/path';
+      const data = {
+        name: 'mocksa',
+        age: 39,
+        location: 'lookpin',
+      };
+
+      await expect(provider.post(path, data, 10000)).rejects.toThrowError(
+        'theson'
+      );
+
+      expect(parserMockFn).toBeCalledTimes(1);
+      expect(mockFnDic.post).toBeCalledWith(path, data, 10000);
+    });
+
+    it('메서드 수행 시 오류가 발생되지 않는다면 parser 가 수행되지 않는다.', async () => {
+      interface MockEntity {
+        items: number[];
+        page: number;
+        size: number;
+      }
+      interface MockParams {
+        keyword?: string;
+        checked?: boolean;
+      }
+      const value: MockEntity = {
+        items: [1, 2, 3, 4, 5],
+        page: 1,
+        size: 10,
+      };
+
+      vi.mocked(mockFnDic.get).mockResolvedValueOnce(value);
+
+      const provider = new NetworkProvider();
+      const path = '/some/search';
+      const params: MockParams = {
+        keyword: 'sonic',
+      };
+
+      const result = await provider.get<MockEntity, MockParams>(path, params);
+
+      expect(result).toEqual(value);
+
+      expect(parserMockFn).not.toBeCalled();
+      expect(mockFnDic.get).toBeCalledTimes(1);
+      expect(mockFnDic.get).toBeCalledWith(path, params);
+      expect(mockFnDic.post).not.toBeCalledWith(path, params);
+    });
+  });
+});

--- a/packages/http-api/ErrorParser.decorator.ts
+++ b/packages/http-api/ErrorParser.decorator.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  AsyncHttpNetworkProvider,
+  AsyncHttpUploadProvider,
+  HttpApi,
+  HttpUploadApi,
+} from './network.type';
+import { throwHttpRestError } from './network.util';
+
+type UnionHttpNetworkProviderType = HttpApi &
+  HttpUploadApi &
+  AsyncHttpNetworkProvider &
+  AsyncHttpUploadProvider;
+
+/**
+ * ### class decorator
+ *
+ * 정해진 타입을 구현한 클래스를 대상으로 오류 내용을 일관성있게 파싱하는 기능을 추가한다.
+ *
+ * 해당 내용
+ *
+ * @param throwableParser 별도로 에러 파싱을 수행할 함수
+ * @returns
+ */
+export function ErrorParser<E = any>(throwableParser: (error: E) => any) {
+  function doParse(error: any): any {
+    const nextError = throwableParser(error);
+
+    if (nextError) {
+      throw nextError;
+    }
+
+    throwHttpRestError(error);
+  }
+
+  return function <
+    C extends {
+      new (...args: any[]): any;
+    }
+  >(ClassConstructor: C): C {
+    if (typeof ClassConstructor !== 'function') {
+      throw new Error('ErrorParser: argument is not function.');
+    }
+
+    return class ErrorParserDecoratedUnionHttpNetworkProvider
+      implements UnionHttpNetworkProviderType
+    {
+      private network = new ClassConstructor() as UnionHttpNetworkProviderType;
+
+      get(...args: any[]) {
+        return this.network.get.apply(this.network, [...args]).catch(doParse);
+      }
+      post(...args: any[]) {
+        return this.network.post.apply(this.network, [...args]).catch(doParse);
+      }
+      put(...args: any[]) {
+        return this.network.put.apply(this.network, [...args]).catch(doParse);
+      }
+      patch(...args: any[]) {
+        return this.network.patch.apply(this.network, [...args]).catch(doParse);
+      }
+      delete(...args: any[]) {
+        return this.network.delete
+          .apply(this.network, [...args])
+          .catch(doParse);
+      }
+      getFile(...args: any[]) {
+        return this.network.getFile
+          .apply(this.network, [...args])
+          .catch(doParse);
+      }
+      getBlob(...args: any[]) {
+        return this.network.getBlob
+          .apply(this.network, [...args])
+          .catch(doParse);
+      }
+      postUpload(...args: any[]) {
+        return this.network.postUpload
+          .apply(this.network, [...args])
+          .catch(doParse);
+      }
+      putUpload(...args: any[]) {
+        return this.network.putUpload
+          .apply(this.network, [...args])
+          .catch(doParse);
+      }
+    } as C;
+  };
+}


### PR DESCRIPTION
## Updates

ErrorParser 를 decorator 형식으로 쓸 수 있는 유틸리티 함수를 작성하였습니다.
추가로 관련 테스트 코드도 함께 작성하였습니다.

## Notes

ErrorParser 디코레이터가 4가지 타입에 대하여 모두 대응해야 했기에
어쩔까.. 하다가
데코레이팅 시 이들이 필요로 하는 메서드는 모두 구현하되 인자(argument) 타입에 관계없이 가변 인자로 가져오도록 하고
내부 수행 메서드는 `Function.apply` 를 활용하였습니다.

원래는 Constructor 의 prototype 에 구성된 메서드를 확인하여 별도 클래스를 리턴하려 했으나
테스트 과정에서 프로토타입 기반 메서드를 반드시 넣게 되리란 보장이 없었기에 선택한 방법입니다.
(이 부분은 이해가 안되신다면 테스트 코드 확인을 부탁드립니다~ 🙏 )

원래 ErrorParser 는 각 메서드별로 데코레이팅 하려 했으나
메서드가 많아지면 일일이 다 세팅 해 줘야 하는 번거로움이 있었고
이 후 작업할 `NetworkInterrupt` 기능 구현에 에로사항(?)이 생기리라 예상되어
부득이하게 class 기반 데코레이터로 만들었습니다.