### PR TITLE
Sub: 기본 HttpApi 및 UploadApi 클래스 작성

### DIFF
--- a/packages/http-api/BasicHttpApi.ts
+++ b/packages/http-api/BasicHttpApi.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { MarshallingType } from '../types';
+import { getFileName } from '../util';
+import { AsyncHttpNetworkProvider, HttpApi } from './network.type';
+
+export class BasicHttpApi implements HttpApi {
+  constructor(
+    private provider: AsyncHttpNetworkProvider,
+    private baseUrl: string,
+    private headersCreator: () => Record<string, string>,
+    private paramsSerializer: (params: any) => string,
+    private withCredentials = true
+  ) {}
+  get<T = MarshallingType, P = void | Record<string, any>>(
+    url: string,
+    params?: P,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.get({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params,
+      timeout,
+    });
+  }
+  post<T = MarshallingType, P = void | Record<string, any>>(
+    url: string,
+    body?: P,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.post({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params: body,
+      timeout,
+    });
+  }
+  put<T = MarshallingType, P = void | Record<string, any>>(
+    url: string,
+    body?: P,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.put({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params: body,
+      timeout,
+    });
+  }
+  patch<T = MarshallingType, P = void | Record<string, any>>(
+    url: string,
+    body?: P,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.patch({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params: body,
+      timeout,
+    });
+  }
+  delete<T = MarshallingType, P = void | Record<string, any>>(
+    url: string,
+    params?: P,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.delete({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params,
+      timeout,
+    });
+  }
+  getFile<P = void | Record<string, any>>(
+    url: string,
+    params?: P,
+    filename?: string
+  ): Promise<File> {
+    return this.getBlob(url, params).then((blob) => {
+      return new File([blob], filename || getFileName(url));
+    });
+  }
+  getBlob<P = void | Record<string, any>>(
+    url: string,
+    params?: P
+  ): Promise<Blob> {
+    return this.provider.getBlob({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      paramsSerializer: this.paramsSerializer,
+      params,
+    });
+  }
+}

--- a/packages/http-api/BasicHttpUploadApi.ts
+++ b/packages/http-api/BasicHttpUploadApi.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  AsyncHttpUploadProvider,
+  HttpUploadApi,
+  UploadStateArgs,
+} from './network.type';
+
+export class BasicHttpUploadApi implements HttpUploadApi {
+  constructor(
+    private provider: AsyncHttpUploadProvider,
+    private baseUrl: string,
+    private headersCreator: () => Record<string, string>,
+    private withCredentials = true
+  ) {}
+  postUpload<
+    T = void,
+    P extends Record<string, any> = Record<string, string | File | File[]>
+  >(
+    url: string,
+    data: P,
+    progressCallback?: (args: UploadStateArgs) => void,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.post({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      data,
+      timeout,
+      onProgress: progressCallback,
+    });
+  }
+  putUpload<
+    T = void,
+    P extends Record<string, any> = Record<string, string | File | File[]>
+  >(
+    url: string,
+    data: P,
+    progressCallback?: (args: UploadStateArgs) => void,
+    timeout?: number
+  ): Promise<T> {
+    return this.provider.put({
+      url: `${this.baseUrl}${url}`,
+      headers: this.headersCreator(),
+      withCredentials: this.withCredentials,
+      data,
+      timeout,
+      onProgress: progressCallback,
+    });
+  }
+}


### PR DESCRIPTION
## Updates

이전 HttpApi 를 대체할 새로운 HttpApi 네트워크 서비스 클래스를 작성하였습니다.
기본적인 Error Parser 는 NetworkProvider 와 HttpApi 사이의 데코레이터가 맡으며
추가적인 Error Parsing 이 필요하다면 이전에 작성한 ErrorParser 데코레이터로 또 한번 기능 추가를 해 주면 됩니다.

## Notes

처음에 시퀀스 다이어그램으로 데이터 방향을 설계하고 진행 중이었는데,
생각보다 괜찮은 방법이 떠오르지 않아 결국 데코레이터(!) 까지 갔습니다 😭 
이후 설계가 또 바뀌지 말란 보장은 없지만,
안바뀐다는 가정하에, ErrorParser 데코레이터를 응용하여 NetworkInterrupt 를 구현 해 볼 예정입니다.